### PR TITLE
Replace removed packages with forked versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
         }
     },
     "require": {
-        "plasmaconduit/dependency-graph": "0.1.*"
+        "mareg/dependency-graph": "0.2.*"
     }
 }


### PR DESCRIPTION
Replaces dependencies:
- from `plasmaconduit/dependency-graph` to `mareg/dependency-graph`
- from `plasmaconduit/map` to `mareg/map`
- from `plasmaconduit/either` to `mareg/either`
- from `plasmaconduit/option` to `mareg/option`